### PR TITLE
Workaround for click-click-dblclick event order 'bug'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Leaflet.singleclick",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/MazeMap/Leaflet.singleclick",
   "authors": [
     "Iván Sánchez Ortega <ivan@mazemap.no>"

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,28 +1,42 @@
 
 
 L.Evented.addInitHook( function () {
+
 	this.on('click', this._scheduleSingleClick, this);
 	this.on('dblclick', this._cancelSingleClick, this);
 
 	this._singleClickTimeout = null;
+	this._cancel = false;
+	this._defaultTimeout = 500;
 });
 
 L.Evented.include({
 
 	_scheduleSingleClick: function(ev) {
-		this._cancelSingleClick();
+		this._cancelSingleClick(false);
+
 		this._singleClickTimeout = window.setTimeout(
 			L.bind(this._fireSingleClick, this, ev),
-			this.options.singleClickTimeout || 500);
+			this.options.singleClickTimeout || this._defaultTimeout);
 	},
 
-	_cancelSingleClick: function() {
+	_cancelSingleClick: function(t) {
 		window.clearTimeout(this._singleClickTimeout);
+		if(t !== false){
+			this._cancel = true;
+        	setTimeout(function(){ this._cancel=false; }.bind(this), (this.options.singleClickTimeout ? this.options.singleClickTimeout + 50 : this._defaultTimeout + 50) );
+		}
 	},
 
 	_fireSingleClick: function(ev) {
-		if (!ev.originalEvent._stopped) {
-			this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+		if (!ev.originalEvent._stopped && !this._cancel) {
+
+	        setTimeout(function(){
+	            if(!this._cancel){
+					this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
+	            }
+	        }.bind(this), 50);
+
 		}
 	}
 })

--- a/singleclick.js
+++ b/singleclick.js
@@ -19,7 +19,9 @@ L.Evented.include({
     },
 
     _fireSingleClick: function(e){
-        this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+        if ( !e.originalEvent._stopped ) {
+            this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+        }
     },
 
     _clearTimeout: function(){

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,43 +1,33 @@
-
-
 L.Evented.addInitHook( function () {
+    this.h = null;
+    this.on( 'click', this.check_later, this );
+    this.on( 'dblclick', this.timeoutClear, this );
 
-	this.on('click', this._scheduleSingleClick, this);
-	this.on('dblclick', this._cancelSingleClick, this);
-
-	this._singleClickTimeout = null;
-	this._cancel = false;
-	this._defaultTimeout = 500;
 });
 
 L.Evented.include({
 
-	_scheduleSingleClick: function(ev) {
-		this._cancelSingleClick(false);
-
-		this._singleClickTimeout = window.setTimeout(
-			L.bind(this._fireSingleClick, this, ev),
-			this.options.singleClickTimeout || this._defaultTimeout);
+	timeoutClear : function(){
+		setTimeout( this.clear_h.bind(this), 0 );
 	},
 
-	_cancelSingleClick: function(t) {
-		window.clearTimeout(this._singleClickTimeout);
-		if(t !== false){
-			this._cancel = true;
-        	setTimeout(function(){ this._cancel=false; }.bind(this), (this.options.singleClickTimeout ? this.options.singleClickTimeout + 50 : this._defaultTimeout + 50) );
-		}
-	},
+    check_later: function(e) {
+        this.clear_h();
 
-	_fireSingleClick: function(ev) {
-		if (!ev.originalEvent._stopped && !this._cancel) {
+        this.h = setTimeout( this.check.bind(this, e), (this.options.singleClickTimeout || 500) );
+    },
 
-	        setTimeout(function(){
-	            if(!this._cancel){
-					this.fire('singleclick', L.Util.extend(ev, {type: 'singleclick'}));
-	            }
-	        }.bind(this), 50);
+    check: function(e){
+        this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
+    },
 
-		}
-	}
+    clear_h: function(){
+        if (this.h != null)
+        {
+            clearTimeout( this.h );
+            this.h = null;
+        }
+    }
+
 })
 

--- a/singleclick.js
+++ b/singleclick.js
@@ -1,31 +1,32 @@
 L.Evented.addInitHook( function () {
-    this.h = null;
-    this.on( 'click', this.check_later, this );
-    this.on( 'dblclick', this.timeoutClear, this );
+    this._timerId = null;
+    this.on( 'click', this._scheduleSingleClick, this );
+    this.on( 'dblclick', this._cancelSingleClick, this );
 
 });
 
 L.Evented.include({
 
-	timeoutClear : function(){
-		setTimeout( this.clear_h.bind(this), 0 );
+	_cancelSingleClick : function(){
+		//This timeout is key to workaround an issue where double-click events are fired in this order on touch browsers: ['click', 'dblclick', 'click'] instead of ['click', 'click', 'dblclick']
+		setTimeout( this._clearTimeout.bind(this), 0 );
 	},
 
-    check_later: function(e) {
-        this.clear_h();
+    _scheduleSingleClick: function(e) {
+        this._clearTimeout();
 
-        this.h = setTimeout( this.check.bind(this, e), (this.options.singleClickTimeout || 500) );
+        this._timerId = setTimeout( this._fireSingleClick.bind(this, e), (this.options.singleClickTimeout || 500) );
     },
 
-    check: function(e){
+    _fireSingleClick: function(e){
         this.fire( 'singleclick', L.Util.extend( e, { type : 'singleclick' } ) );
     },
 
-    clear_h: function(){
-        if (this.h != null)
+    _clearTimeout: function(){
+        if (this._timerId != null)
         {
-            clearTimeout( this.h );
-            this.h = null;
+            clearTimeout( this._timerId );
+            this._timerId = null;
         }
     }
 


### PR DESCRIPTION
Fixes #1

The issue has probably been present since early Leaflet, since the "SmartClick" had already implemented logic to prevent this.

~~Porting over old logic from "SmartClick", using timeouts to fix the issue~~
~~Not very pretty or elegant, but does the trick until a better way is found~~
~~Basically prevents 'click' that happen 'immediately' after a 'dblclick' from firing 'smartclick'~~

Fixing it properly by re-implementing the original logic from Alpstein/leaflet-singleclick_0.7
